### PR TITLE
add 0 return code for successful processing

### DIFF
--- a/src/main.c
+++ b/src/main.c
@@ -183,5 +183,7 @@ int main (int argc, char **argv)
       free (error);
       }
     }
+
+    exit (0);
   }
 


### PR DESCRIPTION
I was integrating this into a larger application and it kept complaining about weird exit codes.  I noticed at at the end no exit code is set (when everything works properly) so I explicitly had it return code 0.  Now it only complains when there's actually an error.