### PR TITLE
Sort input file list

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -9,7 +9,7 @@ MANDIR  := /share/man
 APPNAME := epub2txt
 
 TARGET	:= epub2txt 
-SOURCES := $(shell find src/ -type f -name *.c)
+SOURCES := $(sort $(shell find src/ -type f -name *.c))
 OBJECTS := $(patsubst src/%,build/%,$(SOURCES:.c=.o))
 DEPS	:= $(OBJECTS:.o=.deps)
 


### PR DESCRIPTION
Sort input file list
so that `epub2txt` builds in a reproducible way
in spite of indeterministic filesystem readdir order

See https://reproducible-builds.org/ for why this is good.

This PR was done while working on [reproducible builds for openSUSE](https://en.opensuse.org/openSUSE:Reproducible_Builds).