### PR TITLE
Fix bugs caused by improper handling of TMP/TMPDIR environment variables

### DIFF
--- a/src/util.c
+++ b/src/util.c
@@ -1,0 +1,41 @@
+/*============================================================================
+  epub2txt v2 
+  util.c
+  Copyright (c)2022 Marco Bonelli, GPL v3.0
+============================================================================*/
+
+#include <errno.h>
+#include <string.h>
+#include <unistd.h>
+#include <signal.h>
+#include <sys/wait.h>
+#include "util.h"
+#include "log.h"
+
+/*==========================================================================
+run_command
+Run an helper command through fork + execvp, wait for it to finish and return
+its status. Log execvp errors, and abort execution if abort_on_error is TRUE.
+*==========================================================================*/
+int run_command (const char *const argv[], BOOL abort_on_error)
+  {
+  int status;
+  int pid = fork();
+
+  if (pid == 0)
+    {
+    execvp(argv[0], (char **const)argv);
+    log_error ("Can't execute command \"%s\": %s", argv[0], strerror (errno));
+
+    if (abort_on_error)
+      {
+      kill (getppid(), SIGTERM);
+      _exit (-1);
+      }
+
+    _exit (0);
+    }
+
+  waitpid (pid, &status, 0);
+  return status;
+  }

--- a/src/util.h
+++ b/src/util.h
@@ -1,0 +1,11 @@
+/*============================================================================
+  epub2txt v2 
+  util.h
+  Copyright (c)2022 Marco Bonelli, GPL v3.0
+============================================================================*/
+
+#pragma once
+
+#include "defs.h"
+
+int run_command (const char *const argv[], BOOL abort_on_error);


### PR DESCRIPTION
TL;DR: this PR fixes bugs in `epub2txt_do_file()` which cause stack-based buffer overflow and command injection due to improper handling of TMP/TMPDIR environment variables.

---

## Bugs

There are multiple bugs in the [function `epub2txt_do_file()` in `src/epub2txt.c`](https://github.com/kevinboone/epub2txt2/blob/973ffba2f4d6adbc8d1d740ccc878ff14170b1db/src/epub2txt.c#L393):

1. The environment variables `TMP` and `TMPDIR` read through `getenv()` are copied as is inside fixed-size buffers on the stack using `strcpy()` ([lines 409 and 411](https://github.com/kevinboone/epub2txt2/blob/973ffba2f4d6adbc8d1d740ccc878ff14170b1db/src/epub2txt.c#L409-L411)) and `sprintf()` (lines [450](https://github.com/kevinboone/epub2txt2/blob/973ffba2f4d6adbc8d1d740ccc878ff14170b1db/src/epub2txt.c#L450), [457](https://github.com/kevinboone/epub2txt2/blob/973ffba2f4d6adbc8d1d740ccc878ff14170b1db/src/epub2txt.c#L457), [464](https://github.com/kevinboone/epub2txt2/blob/973ffba2f4d6adbc8d1d740ccc878ff14170b1db/src/epub2txt.c#L464), [493](https://github.com/kevinboone/epub2txt2/blob/973ffba2f4d6adbc8d1d740ccc878ff14170b1db/src/epub2txt.c#L493), [503](https://github.com/kevinboone/epub2txt2/blob/973ffba2f4d6adbc8d1d740ccc878ff14170b1db/src/epub2txt.c#L503)), which uses the same buffers to make additional copies. This can easily cause a stack buffer overflow and crash the program in case the path stored in `TMP` or `TMPDIR` is longer than the destination buffer size.
2. The same environment variables are used to execute the `chmod` and `rm` commands through the `system()` function (line [451](https://github.com/kevinboone/epub2txt2/blob/973ffba2f4d6adbc8d1d740ccc878ff14170b1db/src/epub2txt.c#L452) and [505](https://github.com/kevinboone/epub2txt2/blob/973ffba2f4d6adbc8d1d740ccc878ff14170b1db/src/epub2txt.c#L505)), without any escaping. If the path specified in those variables contains double quote characters (`"`) this breaks the functionality of the program as the command becomes invalid, and can also result in executing unwanted commands (command injection).

The above bugs can also be considered security vulnerabilities, depending on the scenario, as they can lead to the execution of arbitrary code/commands in the context of the application. If we imagine a scenario where this tool is used to convert EPUBs through a cgi-bin web server where users might have partial control over environment variables for temporary directories, this could also result in remote code execution.

Example 1:

```none
$ export TMP=$(printf '%0800d' 0)
$ epub2txt blank.epub
checkdir:  cannot create extraction directory: 000000000000000000000[...]/epub2txt16058
           File name too long
sh: 1: Syntax error: Unterminated quoted string
rm: cannot remove '000000000000000000000[...]rm -rf ': File name too long
rm: cannot remove '000000000000000000000[...]chmod -R 744 000000000000000000000[...]/epub2txt16058': File name too long
Segmentation fault
```

Example 2:

```none
$ export TMP='";echo THIS IS A COMMAND INJECTION;exit 0;"'
$ epub2txt blank.epub
checkdir:  cannot create extraction directory: ";echo THIS IS A COMMAND INJECTION;exit 0;"/epub2txt15941
           No such file or directory
chmod: cannot access '': No such file or directory
THIS IS A COMMAND INJECTION
THIS IS A COMMAND INJECTION
epub2txt: Can't open file '";echo THIS IS A COMMAND INJECTION;exit 0;"/epub2txt15941/META-INF/container.xml' for reading: No such file or directory
```

Note: as these issues are independent of the EPUB being parsed, the `blank.epub` file used for testing above just contains one blank page.

## Fixes

The buffer overflow was solved by simply dynamycally allocating strings with `asprintf()` instead of using fixed-size stack buffers. The second issue of passing unescaped paths to `system()` was solved by adding an helper function (file `src/util.c`) which uses `fork()` + `execvp()` to run helper commands. See also the commit messages for more info.

Additionally, I also added a simple check on the [the `mkdir()` call](https://github.com/kevinboone/epub2txt2/blob/973ffba2f4d6adbc8d1d740ccc878ff14170b1db/src/epub2txt.c#L424) to return early in case of failure, since there isn't much else to do except bail out. Continuing to run code that tries to operate on a non-existent directory isn't going to work anyway.
