### PR TITLE
Sanitize EPUB paths and skip invalid ones

### DIFF
--- a/src/util.c
+++ b/src/util.c
@@ -80,4 +80,18 @@ char *decode_url (const char *url)
   return ret;
   }
 
-
+/*==========================================================================
+  is_subpath
+  Determine whether path is a subpath of root; or in other words, whether path
+  points to a file/directory inside root. Both root and path are assumed to be
+  in canonical form, therefore the caller should make sure of this using e.g.
+  canonicalize_file_name().
+  (Marco Bonelli)
+*==========================================================================*/
+BOOL is_subpath (const char *root, const char *path)
+  {
+    size_t root_len = strlen (root);
+    size_t path_len = strlen (path);
+    return path_len > root_len && !strncmp (root, path, root_len)
+      && path[root_len] == '/';
+  }

--- a/src/util.h
+++ b/src/util.h
@@ -13,3 +13,7 @@ int run_command (const char *const argv[], BOOL abort_on_error);
 /** Decode %xx in URL-type strings. The caller must free the resulting
     string, which will be no longer than the input. */
 char *decode_url (const char *url);
+
+/** Determine whether path is a subpath of root, assuming both paths are in
+    canonical form. */
+BOOL is_subpath (const char *root, const char *path);


### PR DESCRIPTION
Paths specified in `href=` attributes inside an EPUB could potentially point outside the EPUB container (e.g. `href="../../../../outside"`). Make sure this does not happen: abort parsing if the rootfile points outside the EPUB container and skip parsing files with invalid paths, printing a warning.

The check is done through [`canonicalize_file_name(3)`](https://manned.org/canonicalize_file_name.3) (available under `_GNU_SOURCE`) plus a new simple `is_subdir()` helper function in `utils.c`.

This also makes the tool consistent with any other sane EPUB parser/reader tools, which normally skip files with invalid paths and only render valid ones.

**Example**: this EPUB [test_epub.zip](https://github.com/kevinboone/epub2txt2/files/9024302/test_epub.zip) has a section pointing to `../../../../../usr/share/doc/nano/nano.html`. Currently `epub2txt` will happily open, parse and output the contents of `/usr/share/doc/nano/nano.html` (the HTML manual for the `nano` editor, assuming you have it installed).

Before this patch:

```none
$ ./epub2txt test_epub.zip
Test EPUB

Nothing to see here...

- Marco

nano

This manual documents the GNU nano editor, version 5.4.

bull Introduction bull Invoking bull Command-line Options ...

... a lot more text ...
```

After this patch:

```none
$ ./epub2txt test_epub.zip
Test EPUB

Nothing to see here...

- Marco

epub2txt WARN Skipping EPUB file "../../../../../usr/share/doc/nano/nano.html": outside EPUB content directory
```