### PR TITLE
Fix missing signal handler argument name

### DIFF
--- a/src/main.c
+++ b/src/main.c
@@ -20,8 +20,9 @@
 /*============================================================================
   sig_handler 
 ============================================================================*/
-static void sig_handler (int)
+static void sig_handler (int signo)
   {
+  (void)signo;
   epub2txt_cleanup();
   exit (0);
   }


### PR DESCRIPTION
Missing parameter name in `static void sig_handler (int)` can cause compilation errors depending on the compiler. For example, GCC 10 fails with:

```none
gcc -Wall -Wno-unused-result -O3  -DVERSION=\"2.10\" -DAPPNAME=\"epub2txt\" -MD -MF build/main.deps -c -o build/main.o src/main.c
src/main.c: In function ‘sig_handler’:
src/main.c:23:26: error: parameter name omitted
   23 | static void sig_handler (int)
      |                          ^~~
make: *** [Makefile:24: build/main.o] Error 1
```