### PR TITLE
Fix unknown canonicalize_file_path on termux

### DIFF
--- a/src/epub2txt.c
+++ b/src/epub2txt.c
@@ -5,6 +5,7 @@
 ============================================================================*/
 
 #define _GNU_SOURCE
+#define _XOPEN_SOURCE 500
 #include <stdio.h>
 #include <stdlib.h>
 #include <string.h>
@@ -489,7 +490,7 @@ void epub2txt_do_file (const char *file, const Epub2TxtOptions *options,
 
         free (opf);
         asprintf (&tmp, "%s/%s", tempdir, string_cstr (rootfile));
-        opf = canonicalize_file_name (tmp);
+        opf = realpath (tmp, NULL);
         free (tmp);
 
         if (opf == NULL || !is_subpath (tempdir, opf))
@@ -533,7 +534,7 @@ void epub2txt_do_file (const char *file, const Epub2TxtOptions *options,
 	      const char *item = (const char *)list_get (list, i);
 	      free (opf);
 	      asprintf (&tmp, "%s/%s", content_dir, item);
-	      opf = canonicalize_file_name (tmp);
+	      opf = realpath (tmp, NULL);
 	      free (tmp);
 
 	      if (opf == NULL || !is_subpath (content_dir, opf))

--- a/src/util.c
+++ b/src/util.c
@@ -85,7 +85,7 @@ char *decode_url (const char *url)
   Determine whether path is a subpath of root; or in other words, whether path
   points to a file/directory inside root. Both root and path are assumed to be
   in canonical form, therefore the caller should make sure of this using e.g.
-  canonicalize_file_name().
+  canonicalize_file_name(path) or realpath(path, NULL).
   (Marco Bonelli)
 *==========================================================================*/
 BOOL is_subpath (const char *root, const char *path)


### PR DESCRIPTION
When trying to build on Termux, the `canonicalize_file_name` is somehow unknown and the build fails. Based on the [man pages](https://man7.org/linux/man-pages/man3/canonicalize_file_name.3.html), `realpath(path, NULL);` is equivalent, and compiles without issues. Text extraction seems to work fine.

Am I just missing some dependencies?

<details>
<summary>`make` error log</summary>

```bash
~/tools/epub2txt2 $ make
gcc -Wall -Wno-unused-result -O3  -DVERSION=\"2.10\" -DAPPNAME=\"epub2txt\" -MD -MF build/convertutf.deps -c -o build/convertutf.o src/convertutf.c            
gcc -Wall -Wno-unused-result -O3  -DVERSION=\"2.10\" -DAPPNAME=\"epub2txt\" -MD -MF build/epub2txt.deps -c -o build/epub2txt.o src/epub2txt.c                  
src/epub2txt.c:492:15: error: call to undeclared function 'canonicalize_file_name'; ISO C99 and later do not support implicit function declarations [-Wimplicit-function-declaration]
  492 |         opf = canonicalize_file_name (tmp);
      |               ^                              
src/epub2txt.c:492:13: error: incompatible integer to pointer conversion assigning to 'char *' from 'int' [-Wint-conversion]
  492 |         opf = canonicalize_file_name (tmp);
      |             ^ ~~~~~~~~~~~~~~~~~~~~~~~~~~~~   
src/epub2txt.c:536:12: error: incompatible integer to pointer conversion assigning to 'char *' from 'int' [-Wint-conversion]
  536 |               opf = canonicalize_file_name (tmp);                                                   
      |                   ^ ~~~~~~~~~~~~~~~~~~~~~~~~~~~~
3 errors generated.
make: *** [Makefile:24: build/epub2txt.o] Error 1
~/tools/epub2txt2 $
```
</details>